### PR TITLE
[fix][doc]update stats-providers doc

### DIFF
--- a/site3/website/docs/admin/metrics.md
+++ b/site3/website/docs/admin/metrics.md
@@ -14,7 +14,7 @@ Provider | Provider class name
 [Codahale Metrics](https://mvnrepository.com/artifact/org.apache.bookkeeper.stats/codahale-metrics-provider) | `org.apache.bookkeeper.stats.CodahaleMetricsProvider`
 [Prometheus](https://prometheus.io/) | `org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider`
 
-> The [Codahale Metrics]({{ site.github_master }}/bookkeeper-stats-providers/codahale-metrics-provider) stats provider is the default provider.
+> The [Codahale Metrics]({{ site.github_master }}/stats/bookkeeper-stats-providers/codahale-metrics-provider) stats provider is the default provider.
 
 ## Enabling stats providers in bookies
 

--- a/site3/website/docs/admin/metrics.md
+++ b/site3/website/docs/admin/metrics.md
@@ -13,26 +13,9 @@ Provider | Provider class name
 :--------|:-------------------
 [Codahale Metrics](https://mvnrepository.com/artifact/org.apache.bookkeeper.stats/codahale-metrics-provider) | `org.apache.bookkeeper.stats.CodahaleMetricsProvider`
 [Prometheus](https://prometheus.io/) | `org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider`
+[OpenTelemetry Metrics](https://opentelemetry.io/docs/specs/otel/metrics/) | `org.apache.bookkeeper.stats.otel.OtelMetricsProvider`
 
-> The [Codahale Metrics]({{ site.github_master }}/stats/bookkeeper-stats-providers/codahale-metrics-provider) stats provider is the default provider.
+> The [Prometheus]({{ site.github_master }}/stats/bookkeeper-stats-providers/prometheus-metrics-provider) stats provider is the default provider.
 
-## Enabling stats providers in bookies
-
-Two stats-related [configuration parameters](../reference/config/) are available for bookies:
-
-Parameter | Description | Default
-:---------|:------------|:-------
-`enableStatistics` | Whether statistics are enabled for the bookie | `false`
-`sanityCheckMetricsEnabled` | Flag to enable sanity check metrics in bookie stats | `false`
-`statsProviderClass` | The stats provider class used by the bookie | `org.apache.bookkeeper.stats.CodahaleMetricsProvider`
-
-
-To enable stats:
-
-* set the `enableStatistics` parameter to `true`
-* set `statsProviderClass` to the desired provider (see the [table above](#stats-providers) for a listing of classes)
-
-<!-- ## Enabling stats in the bookkeeper library
-
-TODO
--->
+## Metrics Provider Settings
+See [Statistics settings](../reference/config/#statistics).

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -278,7 +278,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true |
 | sanityCheckMetricsEnabled | Flag to enable sanity check metrics in bookie stats. | false |
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - OpenTelemetry    : org.apache.bookkeeper.stats.otel.OtelMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | true | 
 
 


### PR DESCRIPTION
### Motiviations
1、Fix [80ca1f834c9ec5054b6d8757d98126759b9292b4 ](https://github.com/apache/bookkeeper/commit/80ca1f834c9ec5054b6d8757d98126759b9292b4)commit
move `bookkeeper-stats` and `bookkeeper-stats-providers` as submodules of `stats`
2、update stats-providers doc
reference: [stats/bookkeeper-stats-providers](https://github.com/apache/bookkeeper/tree/master/stats/bookkeeper-stats-providers)
